### PR TITLE
Add Chakra UI frontend and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,22 @@ frontend/   # Next.js フロントエンド
 git clone https://github.com/your-repo/kintai-visualizer.git
 cd kintai-visualizer
 
-# 2. Google Cloud Vision APIキーを.env.localへ
+# 2. Python仮想環境（任意）
+python -m venv .venv
+source .venv/bin/activate
+
+# 3. Google Cloud Vision APIキーを.env.localへ
 NEXT_PUBLIC_GCLOUD_API_KEY=xxxxx
-
-# 3. 依存インストール
-npm install           # フロントエンド
-pip install -r backend/requirements.txt    # バックエンド
-
-# 4. 開発サーバ起動
+# 4. 依存インストール
+cd frontend && npm install && cd ..       # フロントエンド依存
+pip install -r backend/requirements.txt    # バックエンド依存
+# 5. 開発サーバ起動
 npm run dev           # フロントエンド
 uvicorn backend.app.main:app --reload   # バックエンド（FastAPI）
 
-# 5. ブラウザで http://localhost:3000 へアクセス
+# 6. ブラウザで http://localhost:3000 へアクセス
 
-# 6. テスト実行例
+# 7. テスト実行例
 pytest backend/tests/         # バックエンドテスト
 ```
 
@@ -202,7 +204,7 @@ type: "給与"
 
 ## 開発状況
 
-- フロントエンドに主要6ページの雛形を追加
+- フロントエンドをChakra UIベースで実装
 - FastAPIに明細アップロード・一覧取得APIを実装
 - pytestによる基本テストを整備
 

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -1,17 +1,18 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
+import { Box, Flex, Link as ChakraLink } from '@chakra-ui/react';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <div>
-      <nav style={{ padding: '1rem', borderBottom: '1px solid #ccc' }}>
-        <Link href="/" style={{ marginRight: '1rem' }}>ホーム</Link>
-        <Link href="/upload" style={{ marginRight: '1rem' }}>アップロード</Link>
-        <Link href="/history" style={{ marginRight: '1rem' }}>明細一覧</Link>
-        <Link href="/visualize" style={{ marginRight: '1rem' }}>グラフ分析</Link>
-        <Link href="/settings" style={{ marginRight: '1rem' }}>設定</Link>
-      </nav>
-      <main style={{ padding: '1rem' }}>{children}</main>
-    </div>
+    <Box>
+      <Flex as="nav" p={4} borderBottom="1px" borderColor="gray.200" gap={4}>
+        <ChakraLink as={Link} href="/">ホーム</ChakraLink>
+        <ChakraLink as={Link} href="/upload">アップロード</ChakraLink>
+        <ChakraLink as={Link} href="/history">明細一覧</ChakraLink>
+        <ChakraLink as={Link} href="/visualize">グラフ分析</ChakraLink>
+        <ChakraLink as={Link} href="/settings">設定</ChakraLink>
+      </Flex>
+      <Box p={4}>{children}</Box>
+    </Box>
   );
 }

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,10 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "swr": "^2.0.0"
+    "swr": "^2.0.0",
+    "@chakra-ui/react": "^2.8.1",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "framer-motion": "^10.16.0"
   }
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,10 @@
+import { AppProps } from 'next/app';
+import { ChakraProvider } from '@chakra-ui/react';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ChakraProvider>
+      <Component {...pageProps} />
+    </ChakraProvider>
+  );
+}

--- a/frontend/pages/history.tsx
+++ b/frontend/pages/history.tsx
@@ -1,5 +1,6 @@
 import useSWR from 'swr';
 import Layout from '../components/Layout';
+import { Heading, List, ListItem, Link } from '@chakra-ui/react';
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
@@ -8,14 +9,14 @@ export default function History() {
 
   return (
     <Layout>
-      <h1>明細一覧</h1>
-      <ul>
+      <Heading as="h1" size="lg" mb={4}>明細一覧</Heading>
+      <List spacing={2}>
         {data?.map((p: any) => (
-          <li key={p.id}>
-            <a href={`/payslip/${p.id}`}>{p.filename}</a>
-          </li>
+          <ListItem key={p.id}>
+            <Link href={`/payslip/${p.id}`} color="teal.500">{p.filename}</Link>
+          </ListItem>
         ))}
-      </ul>
+      </List>
     </Layout>
   );
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,6 @@
 import useSWR from 'swr';
 import Layout from '../components/Layout';
+import { Heading, Text, Stack, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
@@ -8,9 +9,14 @@ export default function Home() {
 
   return (
     <Layout>
-      <h1>ダッシュボード</h1>
-      <p>アップロード済み明細: {data ? data.length : 0} 件</p>
-      {/* グラフやサマリーカードはここに配置予定 */}
+      <Stack spacing={4}>
+        <Heading as="h1" size="lg">ダッシュボード</Heading>
+        <Stat>
+          <StatLabel>アップロード済み明細</StatLabel>
+          <StatNumber>{data ? data.length : 0} 件</StatNumber>
+        </Stat>
+        <Text color="gray.500">グラフやサマリーカードは今後追加予定です。</Text>
+      </Stack>
     </Layout>
   );
 }

--- a/frontend/pages/payslip/[id].tsx
+++ b/frontend/pages/payslip/[id].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import Layout from '../../components/Layout';
+import { Heading, Text, Stack } from '@chakra-ui/react';
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
 
@@ -13,9 +14,11 @@ export default function PayslipDetail() {
 
   return (
     <Layout>
-      <h1>{data.filename}</h1>
-      <p>ID: {data.id}</p>
-      {/* 詳細項目編集フォームなどここに */}
+      <Stack spacing={4}>
+        <Heading as="h1" size="lg">{data.filename}</Heading>
+        <Text>ID: {data.id}</Text>
+        <Text color="gray.500">詳細項目編集フォームは今後追加予定です。</Text>
+      </Stack>
     </Layout>
   );
 }

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -1,10 +1,11 @@
 import Layout from '../components/Layout';
+import { Heading, Text } from '@chakra-ui/react';
 
 export default function Settings() {
   return (
     <Layout>
-      <h1>設定</h1>
-      {/* 設定項目は将来追加 */}
+      <Heading as="h1" size="lg" mb={4}>設定</Heading>
+      <Text color="gray.500">設定項目は今後追加予定です。</Text>
     </Layout>
   );
 }

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Layout from '../components/Layout';
+import { Heading, Input, Button, Text, Stack } from '@chakra-ui/react';
 
 export default function Upload() {
   const [file, setFile] = useState<File | null>(null);
@@ -19,10 +20,12 @@ export default function Upload() {
 
   return (
     <Layout>
-      <h1>明細アップロード</h1>
-      <input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
-      <button onClick={handleUpload}>送信</button>
-      <p>{message}</p>
+      <Stack spacing={4}>
+        <Heading as="h1" size="lg">明細アップロード</Heading>
+        <Input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
+        <Button onClick={handleUpload} colorScheme="teal">送信</Button>
+        {message && <Text>{message}</Text>}
+      </Stack>
     </Layout>
   );
 }

--- a/frontend/pages/visualize.tsx
+++ b/frontend/pages/visualize.tsx
@@ -1,10 +1,11 @@
 import Layout from '../components/Layout';
+import { Heading, Text } from '@chakra-ui/react';
 
 export default function Visualize() {
   return (
     <Layout>
-      <h1>グラフ分析</h1>
-      {/* グラフ描画は将来追加 */}
+      <Heading as="h1" size="lg" mb={4}>グラフ分析</Heading>
+      <Text color="gray.500">グラフ描画機能は今後追加予定です。</Text>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- integrate Chakra UI for a simple layout
- add Chakra UI pages and components
- include Chakra packages in package.json
- document local setup steps and current progress

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68442d9d99dc8329b67c1d00fb2fed78