### PR TITLE
Add upload preview workflow

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -8,6 +8,14 @@ class PayslipBase(BaseModel):
     net_amount: int | None = None
     deduction_amount: int | None = None
 
+class PayslipItem(BaseModel):
+    name: str
+    amount: int
+    category: str | None = None
+
+class PayslipPreview(PayslipBase):
+    items: list[PayslipItem] = []
+
 class PayslipCreate(PayslipBase):
     pass
 

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -1,30 +1,96 @@
 import { useState } from 'react';
 import Layout from '../components/Layout';
-import { Heading, Input, Button, Text, Stack } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Image,
+  Input,
+  Progress,
+  SimpleGrid,
+  Stack,
+  Text
+} from '@chakra-ui/react';
 
 export default function Upload() {
   const [file, setFile] = useState<File | null>(null);
-  const [message, setMessage] = useState('');
+  const [preview, setPreview] = useState<any>(null);
+  const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
 
-  const handleUpload = async () => {
-    if (!file) return;
-    const formData = new FormData();
-    formData.append('file', file);
-    const res = await fetch('/api/payslip/upload', { method: 'POST', body: formData });
-    if (res.ok) {
-      setMessage('アップロードしました');
-    } else {
-      setMessage('アップロード失敗');
+  const upload = async (f: File) => {
+    setProgress(0);
+    setStatus('アップロード中...');
+    setError('');
+    const form = new FormData();
+    form.append('file', f);
+    try {
+      const res = await fetch('/api/payslip/upload', { method: 'POST', body: form });
+      if (res.ok) {
+        const data = await res.json();
+        setPreview(data);
+        setStatus('解析完了');
+      } else {
+        setError('アップロード失敗');
+        setStatus('');
+      }
+    } catch (e) {
+      setError('アップロード失敗');
+      setStatus('');
+    } finally {
+      setProgress(100);
     }
+  };
+
+  const handleFile = (f: File) => {
+    setFile(f);
+    upload(f);
+  };
+
+  const handleSave = async () => {
+    if (!preview) return;
+    await fetch('/api/payslip/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filename: preview.filename,
+        date: preview.date,
+        type: preview.type,
+        gross_amount: preview.gross_amount,
+        net_amount: preview.net_amount,
+        deduction_amount: preview.deduction_amount
+      })
+    });
+    setStatus('保存しました');
   };
 
   return (
     <Layout>
       <Stack spacing={4}>
         <Heading as="h1" size="lg">明細アップロード</Heading>
-        <Input type="file" onChange={e => setFile(e.target.files?.[0] || null)} />
-        <Button onClick={handleUpload} colorScheme="teal">送信</Button>
-        {message && <Text>{message}</Text>}
+        <Input type="file" onChange={e => e.target.files && handleFile(e.target.files[0])} />
+        {progress > 0 && <Progress value={progress} />}
+        {status && <Text>{status}</Text>}
+        {error && <Text color="red.500">{error}</Text>}
+        {preview && (
+          <Box>
+            {file && <Image src={URL.createObjectURL(file)} alt="preview" maxW="200px" />}
+            <SimpleGrid columns={2} spacing={2} mt={2}>
+              {preview.items?.map((it: any, i: number) => (
+                <Box key={i} p={2} borderWidth="1px" borderRadius="md">
+                  <Text fontWeight="bold">{it.name}</Text>
+                  <Text>{it.amount}円</Text>
+                </Box>
+              ))}
+            </SimpleGrid>
+            <Flex gap={2} mt={2}>
+              <Button colorScheme="teal" onClick={handleSave}>保存</Button>
+              <Button onClick={() => file && upload(file)}>再解析</Button>
+            </Flex>
+          </Box>
+        )}
       </Stack>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- implement preview-save workflow for payslip router
- expand schemas with preview models
- update tests for new APIs
- redesign upload page with preview and progress

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6844410502ec8329868413882ddf6c70