### PR TITLE
Switch to react-icons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "next": "^15.3.3",
     "react": "latest",
     "react-dom": "latest",
-    "swr": "^2.0.0"
+    "swr": "^2.0.0",
+    "react-icons": "^4.12.0"
   },
   "devDependencies": {
     "@types/node": "22.15.30",

--- a/frontend/pages/history.tsx
+++ b/frontend/pages/history.tsx
@@ -23,7 +23,7 @@ import {
   ModalBody,
   ModalFooter,
 } from '@chakra-ui/react';
-import { DeleteIcon, CopyIcon, EditIcon, ViewIcon } from '@chakra-ui/icons';
+import { FaTrash, FaCopy, FaEdit, FaEye } from 'react-icons/fa';
 import Link from 'next/link';
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
@@ -114,10 +114,10 @@ export default function History() {
                 <Td isNumeric>{p.deduction_amount?.toLocaleString()}</Td>
                 <Td>
                   <Stack direction="row" spacing={1}>
-                    <IconButton as={Link} href={`/payslip/${p.id}`} aria-label="detail" icon={<ViewIcon />} size="sm" />
-                    <IconButton as={Link} href={`/payslip/${p.id}?edit=1`} aria-label="edit" icon={<EditIcon />} size="sm" />
-                    <IconButton onClick={() => askDelete(p.id)} aria-label="delete" icon={<DeleteIcon />} size="sm" />
-                    <IconButton as={Link} href={`/upload?copy=${p.id}`} aria-label="copy" icon={<CopyIcon />} size="sm" />
+                    <IconButton as={Link} href={`/payslip/${p.id}`} aria-label="detail" icon={<FaEye />} size="sm" />
+                    <IconButton as={Link} href={`/payslip/${p.id}?edit=1`} aria-label="edit" icon={<FaEdit />} size="sm" />
+                    <IconButton onClick={() => askDelete(p.id)} aria-label="delete" icon={<FaTrash />} size="sm" />
+                    <IconButton as={Link} href={`/upload?copy=${p.id}`} aria-label="copy" icon={<FaCopy />} size="sm" />
                   </Stack>
                 </Td>
               </Tr>

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -19,7 +19,7 @@ import {
   Link,
   useColorMode,
 } from '@chakra-ui/react';
-import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import { FaPlus, FaTrash } from 'react-icons/fa';
 
 interface Item {
   id: number;
@@ -125,13 +125,13 @@ export default function Settings() {
                     <Switch isChecked={it.enabled} onChange={e => updateItem(it.id, 'enabled', e.target.checked)} />
                   </Td>
                   <Td>
-                    <IconButton aria-label="delete" icon={<DeleteIcon />} size="sm" onClick={() => removeItem(it.id)} />
+                    <IconButton aria-label="delete" icon={<FaTrash />} size="sm" onClick={() => removeItem(it.id)} />
                   </Td>
                 </Tr>
               ))}
             </Tbody>
           </Table>
-          <Button leftIcon={<AddIcon />} size="sm" mt={2} onClick={addItem}>追加</Button>
+          <Button leftIcon={<FaPlus />} size="sm" mt={2} onClick={addItem}>追加</Button>
         </Box>
 
         <Box>


### PR DESCRIPTION
## Summary
- use `react-icons` instead of `@chakra-ui/icons`
- change history and settings pages to use FontAwesome icons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` in `frontend` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444ba3f5d4832983a6d1705b1bbc60