### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ uvicorn backend.app.main:app --reload   # バックエンド（FastAPI）
 pytest backend/tests/         # バックエンドテスト
 ```
 
+## Docker Compose を使った起動
+
+Docker が利用できる環境であれば、フロントエンドとバックエンドをまとめて起動できます。
+
+```bash
+docker-compose up --build
+```
+
+- Frontend: <http://localhost:3000>
+- Backend: <http://localhost:8000>
+
 ---
 
 ## テスト

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ./app /app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    depends_on:
+      - backend
+
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json .
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- add Dockerfile for Next.js frontend
- add Dockerfile for FastAPI backend
- provide docker-compose configuration to run both services
- document Docker Compose usage in README

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684452d490b883299b8a56e6abb3fc36