### PR TITLE
Fix FastAPI startup issues

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
-from .routers import payslip, settings
-from .database import engine
-from . import models
+from app.routers import payslip, settings
+from app.database import engine
+from app import models
 
 models.Base.metadata.create_all(bind=engine)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+python-multipart


### PR DESCRIPTION
## Summary
- import routers and database using absolute paths
- install python-multipart for form parsing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68446b0c67c08329883273b9178868f7