### PR TITLE
Fix router loading and update Pydantic config

### DIFF
--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import payslip, settings
+
+__all__ = ["payslip", "settings"]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,5 +31,6 @@ class Payslip(PayslipBase):
     id: int
     items: list[PayslipItem] = []
 
-    class Config:
-        orm_mode = True
+    model_config = {
+        "from_attributes": True,
+    }


### PR DESCRIPTION
## Summary
- add `routers/__init__.py` so the package imports cleanly
- switch pydantic model configuration to use `from_attributes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68446ec0cd188329af8bcff9d294d23c