### PR TITLE
Fix API path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ docker-compose up --build
 - Frontend: <http://localhost:3000>
 - Backend: <http://localhost:8000>
 
+フロントエンドからバックエンド API へのアクセスにはリバースプロキシを利用しており
+`API_HOST` 環境変数で接続先を指定できます。Docker Compose 起動時は自動で
+`http://backend:8000` が設定されます。ローカルで個別に起動する場合は次のように
+環境変数を指定してフロントエンドを起動してください。
+
+```bash
+API_HOST=http://localhost:8000 npm run dev
+```
+
 ---
 
 ## テスト

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/app
+    environment:
+      - API_HOST=http://backend:8000
     depends_on:
       - backend
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,15 @@
+const API_HOST = process.env.API_HOST || 'http://localhost:8000';
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${API_HOST}/api/:path*`,
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- route `/api` requests to FastAPI backend via Next.js `rewrites`
- set `API_HOST` environment variable in docker-compose
- document how to specify `API_HOST`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6844705f9b6c83299a5cfbbb000fe0c5