### PR TITLE
Ensure OCR via Google Vision

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -100,18 +100,19 @@ def _categorize_items(items: list[PayslipItem]) -> list[PayslipItem]:
 
 
 def _parse_file(content: bytes) -> dict:
-    """Parse uploaded file using OCR when necessary."""
+    """Parse uploaded file using OCR when possible."""
     logger.debug("Parsing uploaded file")
-    text = content.decode('utf-8', errors='ignore')
-    parsed = _parse_text(text)
-    if not parsed['items'] and _vision_available:
+
+    vision_text = ''
+    if _vision_available:
         try:
             vision_text = _extract_text_with_vision(content)
         except Exception as e:
             logger.error("Vision API request failed: %s", e)
-            vision_text = ''
-        parsed = _parse_text(vision_text)
-    
+
+    text = vision_text or content.decode('utf-8', errors='ignore')
+    parsed = _parse_text(text)
+
     parsed['items'] = _categorize_items(parsed['items'])
     return parsed
 


### PR DESCRIPTION
## Summary
- always use Google Vision API first when parsing uploaded payslip

## Testing
- `python -m py_compile backend/app/routers/payslip.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684486b4e9dc8329a9e9dc90b0a169bb