### PR TITLE
Improve Vision API log clarity

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,13 @@ from fastapi import FastAPI
 from app.routers import payslip, settings
 from app.database import engine
 from app import models
+import logging
+
+# Ensure application logs show informative messages
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s:%(name)s:%(message)s"
+)
 
 models.Base.metadata.create_all(bind=engine)
 

--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -9,6 +9,9 @@ import logging
 import re
 
 logger = logging.getLogger(__name__)
+# Ensure INFO level logs are emitted even when root logger level is higher
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
 try:
     from google.cloud import vision  # type: ignore
     _vision_available = True
@@ -109,6 +112,8 @@ def _parse_file(content: bytes) -> dict:
             vision_text = _extract_text_with_vision(content)
         except Exception as e:
             logger.error("Vision API request failed: %s", e)
+    else:
+        logger.warning("Vision API client not loaded; skipping OCR")
 
     text = vision_text or content.decode('utf-8', errors='ignore')
     parsed = _parse_text(text)


### PR DESCRIPTION
## Summary
- configure global logging in FastAPI app
- raise logging level of payslip router and log when Vision API is not used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68448cb25f40832996d28826a5916cf0