### PR TITLE
Add script to save API responses

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ sqlalchemy
 pydantic
 python-multipart
 google-cloud-vision
+
+requests

--- a/dev/save_response.py
+++ b/dev/save_response.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import sys
+import json
+import os
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - requests may not be installed
+    print("The 'requests' library is required. Install with 'pip install requests'.")
+    raise
+
+
+def main():
+    url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8000/"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    try:
+        data = resp.json()
+    except ValueError:
+        data = resp.text
+    os.makedirs("dev", exist_ok=True)
+    path = os.path.join("dev", "result.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2) if isinstance(data, dict) or isinstance(data, list) else f.write(str(data))
+    print(f"API response from {url} saved to {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `dev/save_response.py` to fetch an API endpoint and save the response
- add `requests` to backend requirements for the script

## Testing
- `pip install -r backend/requirements.txt` *(fails: `Tunnel connection failed: 403 Forbidden`)*
- `pytest -q` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684490eb1690832994ef6f12964caa86