### PR TITLE
Add dev mount for backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "8000:8000"
     volumes:
       - ./backend:/app
+      - ./dev:/app/dev
       - ./gcp_key.json:/run/secrets/gcp_key.json:ro
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp_key.json


### PR DESCRIPTION
## Summary
- mount the `dev` directory into the backend service for sharing development scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68449b817fb48329b218151c730801b4