### PR TITLE
Add unknown item handling and sections

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -118,7 +118,7 @@ def _parse_text(text: str) -> dict:
         except ValueError:
             continue
 
-        items.append(PayslipItem(name=name, amount=amount, category=current_section))
+        items.append(PayslipItem(name=name, amount=amount, section=current_section))
         if name in GROSS_KEYS:
             gross = amount
         if name in NET_KEYS:
@@ -143,8 +143,16 @@ def _categorize_items(items: list[PayslipItem]) -> list[PayslipItem]:
                 category = 'deduction'
             else:
                 category = 'payment'
+            if it.name not in CATEGORY_MAP:
+                logger.info("Unknown item name encountered: %s -> %s", it.name, category)
         categorized.append(
-            PayslipItem(id=it.id, name=it.name, amount=it.amount, category=category)
+            PayslipItem(
+                id=it.id,
+                name=it.name,
+                amount=it.amount,
+                category=category,
+                section=it.section,
+            )
         )
     return categorized
 
@@ -268,7 +276,15 @@ def reparse_payslip(data: ReparseRequest):
     items = []
     for it in data.items:
         category = 'deduction' if it.amount < 0 else 'payment'
-        items.append(PayslipItem(id=it.id, name=it.name, amount=it.amount, category=category))
+        items.append(
+            PayslipItem(
+                id=it.id,
+                name=it.name,
+                amount=it.amount,
+                category=category,
+                section=it.section,
+            )
+        )
     return items
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -13,6 +13,7 @@ class PayslipItem(BaseModel):
     name: str
     amount: int
     category: str | None = None
+    section: str | None = None
 
 class PayslipPreview(PayslipBase):
     items: list[PayslipItem] = []

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -177,3 +177,11 @@ def test_export_and_settings_update():
     upd = client.post('/api/settings/update', json={'theme_color': '#ffffff'})
     assert upd.status_code == 200
     assert upd.json()['theme_color'] == '#ffffff'
+
+
+def test_unknown_item_fallback():
+    resp = client.post('/api/payslip/upload', files={'file': ('unk.txt', b'FooBar:30')})
+    assert resp.status_code == 200
+    preview = resp.json()
+    assert preview['items']
+    assert preview['items'][0]['category'] in ['payment', 'deduction']


### PR DESCRIPTION
## Summary
- log and categorize unknown item names
- preserve original section info during parsing
- test fallback behavior

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6844f0d1a6348329b33a2bdb0b700e86