### PR TITLE
Improve OCR parsing logic

### DIFF
--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -1,0 +1,17 @@
+from backend.app.routers.payslip import _parse_text
+
+
+def test_parse_trailing_number_removed_and_small_amount_skip():
+    text = "口座振込額1 123\n手当2\n5"
+    result = _parse_text(text)
+    items = result['items']
+    assert any(it.name == '口座振込額' and it.amount == 123 for it in items)
+    assert all(it.amount >= 10 or it.amount <= -10 for it in items)
+
+
+def test_parse_split_lines():
+    text = "基本給\n200000"
+    result = _parse_text(text)
+    items = result['items']
+    assert any(it.name == '基本給' and it.amount == 200000 for it in items)
+


### PR DESCRIPTION
## Summary
- skip suspicious small amounts under 10
- strip trailing digits from item names
- ignore known section labels when pairing names and amounts
- support pairing item names and amounts across lines
- add unit tests for the parser

## Testing
- `python -m py_compile backend/app/routers/payslip.py`
- `python -m py_compile backend/tests/test_parser.py`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6844f6a822188329b462a12908fa7892