### PR TITLE
Improve OCR parser

### DIFF
--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -46,3 +46,12 @@ def test_item_line_pattern_with_amount_at_end():
     assert any(it.name == '通勤費補助' and it.amount == 12860 for it in items)
     assert any(it.name == '通勤費補助' and it.category == 'payment' for it in items)
 
+
+def test_amount_first_with_pending_name_queue():
+    text = "課税対象額\n口座振込額1\n135,545 雇保対象額\n218,919\n148,405"
+    result = _parse_text(text)
+    names = [it.name for it in result['items']]
+    amounts = [it.amount for it in result['items']]
+    assert names == ['課税対象額', '口座振込額', '雇保対象額']
+    assert amounts == [135545, 218919, 148405]
+    assert all(it.name for it in result['items'])


### PR DESCRIPTION
## Summary
- fix pending item handling for amount-first OCR lines
- skip unlabelled small amounts and reset section after totals
- classify bank transfer amounts as net
- refine slip type detection
- test pending name queue logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_parser.py::test_amount_first_with_pending_name_queue -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68450da1dee883299cae31fe108daaf8