### PR TITLE
Fix payslip section detection

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -248,7 +248,7 @@ def _parse_text(text: str) -> dict:
                 pending_items.clear()
                 continue
             section = current_section
-            if ATTENDANCE_PATTERN.search(name):
+            if section is None and ATTENDANCE_PATTERN.search(name):
                 section = "attendance"
 
             if name in TOTAL_KEYS:
@@ -281,7 +281,7 @@ def _parse_text(text: str) -> dict:
                     pending_items.clear()
                     continue
                 section = current_section
-                if ATTENDANCE_PATTERN.search(name):
+                if section is None and ATTENDANCE_PATTERN.search(name):
                     section = "attendance"
                 if name in TOTAL_KEYS:
                     if name in GROSS_KEYS:
@@ -351,7 +351,7 @@ def _parse_text(text: str) -> dict:
                 pending_items.clear()
                 continue
             section = current_section
-            if ATTENDANCE_PATTERN.search(name):
+            if section is None and ATTENDANCE_PATTERN.search(name):
                 section = "attendance"
             if name in TOTAL_KEYS:
                 if name in GROSS_KEYS:

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -76,3 +76,12 @@ def test_totals_not_in_items():
     assert result["gross_amount"] == 100000
     assert result["net_amount"] == 100000
     assert result["deduction_amount"] == 0
+
+def test_section_assignment():
+    text = "支給項目\n本給 100000\n控除項目\n所得税 -5000\n勤怠項目\n欠勤日数 2"
+    result = _parse_text(text)
+    items = result["items"]
+    sections = {it.name: it.section for it in items}
+    assert sections.get("本給") == "payment"
+    assert sections.get("所得税") == "deduction"
+    assert sections.get("欠勤日数") == "attendance"


### PR DESCRIPTION
## Summary
- fix section assignment when parsing payslips so attendance detection only triggers without a known section
- test that section headers map correctly

## Testing
- `pytest backend/tests/test_parser.py::test_section_assignment -q`
- `pytest -q` *(fails: KeyError and assertion errors from test_main suite)*

------
https://chatgpt.com/codex/tasks/task_e_68453d14f90c8329bd325b140d1c251c