### PR TITLE
Fix section detection in payslip parser

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -216,13 +216,18 @@ def _parse_text(text: str) -> dict:
             pending_names.clear()
             continue
 
-        if line in SECTION_MAP:
-            current_section = SECTION_MAP[line]
+        matched_section = None
+        for sec_label, sec_name in SECTION_MAP.items():
+            if re.fullmatch(rf"{re.escape(sec_label)}[：:]*", line):
+                matched_section = sec_name
+                break
+        if matched_section:
+            current_section = matched_section
             pending_names.clear()
             continue
 
-        if line in KNOWN_SECTION_LABELS:
-            cleaned = re.sub(r"\d+$", "", line.strip())
+        if any(re.fullmatch(rf"{re.escape(lbl)}[：:]*\d*", line) for lbl in KNOWN_SECTION_LABELS):
+            cleaned = re.sub(r"[\d：:]+$", "", line.strip())
             if cleaned:
                 pending_names.append(cleaned)
             else:

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -95,3 +95,11 @@ def test_multi_pair_and_section_category():
     assert categories.get("東友会費") == "deduction"
     assert categories.get("共済会費") == "deduction"
     assert len(items) == 4
+
+
+def test_section_with_colon_and_split_lines():
+    text = "支給項目:\n本給\n269000\n控除項目：\n所得税\n2460"
+    result = _parse_text(text)
+    items = {it.name: (it.amount, it.section) for it in result["items"]}
+    assert items.get("本給") == (269000, "payment")
+    assert items.get("所得税") == (2460, "deduction")


### PR DESCRIPTION
## Summary
- improve section header detection by allowing trailing colon symbols
- new test for header detection with colon and split lines

## Testing
- `pytest backend/tests/test_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68455e5f0cb08329bca7c4b0b8ca4638