### PR TITLE
Improve totals parsing and add consistency warnings

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,6 +18,7 @@ class PayslipItem(BaseModel):
 
 class PayslipPreview(PayslipBase):
     items: list[PayslipItem] = []
+    warnings: list[str] | None = None
 
 class PayslipCreate(PayslipBase):
     items: list[PayslipItem] = []

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -185,3 +185,11 @@ def test_unknown_item_fallback():
     preview = resp.json()
     assert preview['items']
     assert preview['items'][0]['category'] in ['payment', 'deduction']
+
+
+def test_upload_warnings():
+    content = b'foo 100\nbar -10\n\xe6\x94\xaf\xe7\xb5\xa6\xe5\x90\x88\xe8\xa8\x88 50\n\xe5\xb7\xae\xe5\xbc\x95\xe6\x94\xaf\xe7\xb5\xa6\xe9\xa1\x8d 80'
+    resp = client.post('/api/payslip/upload', files={'file': ('warn.txt', content)})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get('warnings')

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -53,9 +53,9 @@ def test_amount_first_with_pending_name_queue():
     result = _parse_text(text)
     names = [it.name for it in result["items"]]
     amounts = [it.amount for it in result["items"]]
-    assert names == ["課税対象額", "口座振込額", "雇保対象額"]
-    assert amounts == [135545, 218919, 148405]
-    assert all(it.name for it in result["items"])
+    assert names == ["課税対象額", "雇保対象額"]
+    assert amounts == [135545, 148405]
+    assert result["net_amount"] == 218919
 
 
 def test_amount_only_with_unit_and_pending_name():


### PR DESCRIPTION
## Summary
- map `当月総支給額累計` and `口座振込額` lines to totals
- add `_normalize_items` and `_consistency_check` for audit warnings
- return warnings from upload API
- adjust breakdown aggregation and tests

## Testing
- `pytest -q` *(fails: missing fastapi dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68458f0227b48329ac2da1c7d578e086