### PR TITLE
Implement totals fixes and UI badges

### DIFF
--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -320,3 +320,11 @@ def test_total_line_strict():
     assert result["gross_amount"] == 222795
     assert result["net_amount"] == 218919
     assert result["deduction_amount"] is None
+
+
+def test_totals_are_not_cumulative():
+    text = "当月総支給額累計 673,095\n支給合計 356,300\n控除合計 53,123\n差引支給額 303,177"
+    r = _parse_text(text)
+    assert r["gross_amount"] == 356300
+    assert r["deduction_amount"] == 53123
+    assert r["net_amount"] == 303177

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -42,6 +42,10 @@ export default function Home() {
             <StatNumber>{summary ? summary.gross_this_month : '--'}円</StatNumber>
           </Stat>
           <Stat>
+            <StatLabel>今月控除</StatLabel>
+            <StatNumber>{summary ? summary.deduction_this_month ?? 0 : '--'}円</StatNumber>
+          </Stat>
+          <Stat>
             <StatLabel>賞与累計</StatLabel>
             <StatNumber>{summary ? summary.bonus_total : '--'}円</StatNumber>
           </Stat>

--- a/frontend/pages/payslip/[id].tsx
+++ b/frontend/pages/payslip/[id].tsx
@@ -13,6 +13,7 @@ import {
   NumberInputField,
   Select,
   Button,
+  Badge,
 } from '@chakra-ui/react';
 
 const fetcher = (url: string) => fetch(url).then(r => r.json());
@@ -80,6 +81,9 @@ export default function PayslipDetail() {
     <Layout>
       <Stack spacing={4}>
         <Heading as="h1" size="lg">{data.filename}</Heading>
+        {data.warnings && data.warnings.length > 0 && (
+          <Badge colorScheme="red">⚠ 内訳と合計が一致しません</Badge>
+        )}
         <Flex gap={4} align="flex-start" direction={{ base: 'column', md: 'row' }}>
           <Box flex="1" minW="200px">
             <Text color="gray.500">画像表示は未実装</Text>


### PR DESCRIPTION
## Summary
- handle cumulative total labels correctly
- capture totals when amount lines follow pending total names
- recompute totals after parsing and warn if inconsistent
- expose deduction totals in summary API
- show deduction total on dashboard
- display warning badge on payslip details
- add regression test for cumulative totals

## Testing
- `pytest -k totals -q`
- `pip install fastapi starlette sqlalchemy pydantic uvicorn --quiet` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: KeyError: 'gross_amount')*

------
https://chatgpt.com/codex/tasks/task_e_68459443b748832993b18c2692503c67