### PR TITLE
Apply fixes for totals and frontend UX

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const [period, setPeriod] = useState<'monthly' | 'yearly'>('monthly');
   const { data: stats } = useSWR(`/api/payslip/stats?target=${target}&period=${period}`, fetcher);
 
-  const hasData = !!(stats && stats.labels && stats.labels.length > 0);
+  const hasData = stats?.data?.some(v => v !== 0);
   const chartData = {
     labels: stats?.labels || [],
     datasets: [
@@ -43,7 +43,7 @@ export default function Home() {
           </Stat>
           <Stat>
             <StatLabel>今月控除</StatLabel>
-            <StatNumber>{summary ? summary.deduction_this_month ?? 0 : '--'}円</StatNumber>
+            <StatNumber>{summary?.deduction_this_month ?? '--'}円</StatNumber>
           </Stat>
           <Stat>
             <StatLabel>賞与累計</StatLabel>
@@ -74,7 +74,7 @@ export default function Home() {
             </Tabs>
           </React.Fragment>
         ) : (
-          <Text color="gray.500">アップロードしてはじめよう！</Text>
+          <Text color="gray.500">データなし</Text>
         )
         }
       </Stack>

--- a/frontend/pages/payslip/[id].tsx
+++ b/frontend/pages/payslip/[id].tsx
@@ -71,7 +71,7 @@ export default function PayslipDetail() {
       body: JSON.stringify({ ...data, items }),
     });
     if (res.ok) {
-      router.push('/history');
+      router.push('/');
     }
   };
 
@@ -82,7 +82,11 @@ export default function PayslipDetail() {
       <Stack spacing={4}>
         <Heading as="h1" size="lg">{data.filename}</Heading>
         {data.warnings && data.warnings.length > 0 && (
-          <Badge colorScheme="red">⚠ 内訳と合計が一致しません</Badge>
+          <Stack>
+            {data.warnings.map((w: string, i: number) => (
+              <Badge key={i} colorScheme="red">⚠ {w}</Badge>
+            ))}
+          </Stack>
         )}
         <Flex gap={4} align="flex-start" direction={{ base: 'column', md: 'row' }}>
           <Box flex="1" minW="200px">

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -76,10 +76,10 @@ export default function Upload() {
         type: preview.type,
         gross_amount: preview.gross_amount,
         net_amount: preview.net_amount,
-        deduction_amount: preview.deduction_amount
+      deduction_amount: preview.deduction_amount
       })
     });
-    setStatus('保存しました');
+    setStatus(`保存しました: 総支給額${preview.gross_amount}円 手取り${preview.net_amount}円`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- handle cumulative lines better when parsing totals
- ensure stats API returns empty data when all zero
- show graph only with real data and tweak deduction display
- improve payslip edit and upload flows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and assertion errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68459ac766fc83298b070e61808ce6f7