### PR TITLE
Fix totals calculation

### DIFF
--- a/frontend/pages/history.tsx
+++ b/frontend/pages/history.tsx
@@ -104,12 +104,12 @@ export default function History() {
           </Thead>
           <Tbody>
             {filtered.map((p: any) => (
-              <Tr key={p.id}>
+              <Tr key={p.id} bg={!p.gross_amount ? 'yellow.50' : undefined}>
                 <Td>{p.date || '-'}</Td>
                 <Td>
                   <Tag colorScheme={p.type === 'bonus' ? 'pink' : 'teal'}>{p.type || '-'}</Tag>
                 </Td>
-                <Td isNumeric>{p.gross_amount?.toLocaleString()}</Td>
+                <Td isNumeric>{p.gross_amount ? p.gross_amount.toLocaleString() : '–'}</Td>
                 <Td isNumeric>{p.net_amount?.toLocaleString()}</Td>
                 <Td isNumeric>{p.deduction_amount?.toLocaleString()}</Td>
                 <Td>


### PR DESCRIPTION
## Summary
- recalc totals server-side whenever items change
- log incoming and fixed totals on save
- default undefined totals to 0 when returning pay slip data
- highlight rows with missing gross amount in history page

## Testing
- `pytest -q` *(fails: Could not assert FastAPI responses since dependencies were missing)*

------
https://chatgpt.com/codex/tasks/task_e_68460eb2b9288329ac39a4d96a738ec5