### PR TITLE
Improve payslip parsing and show message on upload save

### DIFF
--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -79,7 +79,8 @@ export default function Upload() {
       deduction_amount: preview.deduction_amount
       })
     });
-    setStatus(`保存しました: 総支給額${preview.gross_amount}円 手取り${preview.net_amount}円`);
+    setPreview(null);
+    setStatus(`保存しました: 総支給額${preview.gross_amount}円 手取り${preview.net_amount}円\n今月もよく頑張りましたね！`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- strengthen OCR parser by tracking section boundaries and skipping irrelevant lines
- clear preview after saving an uploaded payslip and show encouragement message

## Testing
- `pytest -q` *(fails: KeyError & AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6846ca88c85c832993739fe28749bad8