### PR TITLE
Fix until_marker regex bug

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -438,9 +438,10 @@ def _parse_text(text: str) -> dict:
         if matched_start and not line:
             continue
         if until_marker and line.startswith(until_marker):
+            marker = until_marker
             current_section = None
             until_marker = None
-            remainder = re.sub(rf"^{re.escape(until_marker)}[：:]*\s*", "", line)
+            remainder = re.sub(rf"^{re.escape(marker)}[：:]*\s*", "", line)
             line = remainder
             if not line:
                 continue


### PR DESCRIPTION
## Summary
- fix regex parsing when closing section to avoid NoneType error

## Testing
- `pytest -q` *(fails: 11 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6846cde2f51483298fda15eb1f9bae38