### PR TITLE
Fix payslip deletion and totals parser

### DIFF
--- a/backend/app/ocr/simple_totals.py
+++ b/backend/app/ocr/simple_totals.py
@@ -24,6 +24,10 @@ class TotalsOnlyParser(BaseParser):
                 net = val
         if gross is None and net is not None and deduction is not None:
             gross = net + deduction
+        if deduction is None and gross is not None and net is not None:
+            deduction = gross - net
+        if net is None and gross is not None and deduction is not None:
+            net = gross - deduction
         if any(v is None for v in (gross, deduction, net)):
             raise ValueError("Totals not found")
         return OCRResult(gross=gross, deduction=deduction, net=net, text=text)

--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -150,3 +150,21 @@ def payslip_stats(
     if all(v == 0 for v in data):
         return {"labels": [], "data": []}
     return {"labels": labels, "data": data}
+
+
+@router.get("/{payslip_id}", response_model=PayslipRead)
+def get_one(payslip_id: int, db: Session = Depends(get_db)):
+    p = db.query(models.Payslip).get(payslip_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="Not found")
+    return to_schema(p)
+
+
+@router.delete("/delete")
+def delete_payslip(payslip_id: int, db: Session = Depends(get_db)):
+    p = db.query(models.Payslip).get(payslip_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="Not found")
+    db.delete(p)
+    db.commit()
+    return {"status": "deleted"}

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -17,3 +17,21 @@ def test_parse_without_gross():
     assert result.gross == 100
     assert result.net == 80
     assert result.deduction == 20
+
+
+def test_parse_without_deduction():
+    parser = TotalsOnlyParser()
+    data = "支給合計 120\n差引支給額 100".encode()
+    result = parser.parse(data)
+    assert result.gross == 120
+    assert result.deduction == 20
+    assert result.net == 100
+
+
+def test_parse_without_net():
+    parser = TotalsOnlyParser()
+    data = "支給合計 120\n控除合計 20".encode()
+    result = parser.parse(data)
+    assert result.gross == 120
+    assert result.deduction == 20
+    assert result.net == 100


### PR DESCRIPTION
## Summary
- add missing payslip GET and DELETE endpoints
- infer missing totals in `TotalsOnlyParser`
- extend parser unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d73f208c832982a8924ec92a651a