### PR TITLE
Enable image uploads with Vision API

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ python -m venv .venv
 source .venv/bin/activate
 
 # 3. Google Cloud Vision APIキーを.env.localへ
-NEXT_PUBLIC_GCLOUD_API_KEY=xxxxx
+NEXT_PUBLIC_GCLOUD_API_KEY=xxxxx  # フロントエンド用
+GCLOUD_API_KEY=xxxxx              # バックエンド用
 # 4. 依存インストール
 cd frontend && npm install && cd ..       # フロントエンド依存
 pip install -r backend/requirements.txt    # バックエンド依存

--- a/backend/app/ocr/simple_totals.py
+++ b/backend/app/ocr/simple_totals.py
@@ -1,4 +1,6 @@
 import re
+import base64
+import os
 from .strategy import BaseParser, OCRResult
 
 TOTAL_PAT = re.compile(r"(支給合計|控除合計|差引支給額)[^\d\-]*([\-\d,()]+)")
@@ -7,8 +9,36 @@ def _clean(n: str) -> int:
     return int(n.replace(",", "").replace("(", "-").replace(")", ""))
 
 def call_vision_api(content: bytes) -> str:
-    """Placeholder Vision API call."""
-    return content.decode('utf-8', errors='ignore')
+    """Return text from given image/PDF content using Google Cloud Vision API.
+
+    If `GCLOUD_API_KEY` (or `NEXT_PUBLIC_GCLOUD_API_KEY`) is not set, this
+    function simply decodes the bytes as UTF-8 and returns the result. This
+    keeps unit tests offline while enabling real OCR when an API key is
+    provided.
+    """
+
+    api_key = os.getenv("GCLOUD_API_KEY") or os.getenv("NEXT_PUBLIC_GCLOUD_API_KEY")
+    if not api_key:
+        return content.decode("utf-8", errors="ignore")
+
+    try:
+        import requests  # imported lazily to avoid hard dependency during tests
+    except Exception as e:  # pragma: no cover - optional dependency
+        raise RuntimeError("requests library is required for OCR") from e
+
+    endpoint = f"https://vision.googleapis.com/v1/images:annotate?key={api_key}"
+    payload = {
+        "requests": [
+            {
+                "image": {"content": base64.b64encode(content).decode()},
+                "features": [{"type": "TEXT_DETECTION"}],
+            }
+        ]
+    }
+    resp = requests.post(endpoint, json=payload, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["responses"][0].get("fullTextAnnotation", {}).get("text", "")
 
 class TotalsOnlyParser(BaseParser):
     def parse(self, content: bytes) -> OCRResult:


### PR DESCRIPTION
## Summary
- integrate Google Cloud Vision API for OCR
- mention `GCLOUD_API_KEY` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d95c20a083299b66320af0f65ed1