### PR TITLE
Fix payslip upload to accept month form field

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -1,5 +1,5 @@
 from datetime import datetime, date, timedelta
-from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
+from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from .. import database, models
@@ -46,7 +46,10 @@ def to_schema(p: models.Payslip) -> PayslipRead:
 
 
 @router.post("/upload", response_model=PayslipPreview)
-async def upload(file: UploadFile = File(...)):
+async def upload(
+    file: UploadFile = File(...),
+    year_month: str | None = Form(None),
+):
     try:
         result = parser.parse(await file.read())
     except ValueError as e:

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -24,12 +24,13 @@ export default function Upload() {
   const toast = useToast();
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const upload = async (f: File) => {
+  const upload = async (f: File, monthValue: string) => {
     setProgress(0);
     setStatus('アップロード中...');
     setError('');
     const form = new FormData();
     form.append('file', f);
+    form.append('year_month', monthValue);
     try {
       const res = await fetch('/api/payslip/upload', { method: 'POST', body: form });
       if (res.ok) {
@@ -52,7 +53,7 @@ export default function Upload() {
 
   const handleFile = (f: File) => {
     setFile(f);
-    upload(f);
+    upload(f, month);
   };
 
   const handleCancel = () => {
@@ -108,7 +109,7 @@ export default function Upload() {
             </SimpleGrid>
             <Flex gap={2} mt={2}>
               <Button colorScheme="teal" onClick={handleSave}>保存</Button>
-              <Button onClick={() => file && upload(file)}>再解析</Button>
+              <Button onClick={() => file && upload(file, month)}>再解析</Button>
             </Flex>
           </Box>
         )}


### PR DESCRIPTION
## Summary
- allow `/api/payslip/upload` to receive a `year_month` value via `Form`
- send the month field from the upload page so backend can parse it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dd36d42083299aa76a7a04ccaffd