### PR TITLE
Fix PayslipPreview items field

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -60,6 +60,7 @@ async def upload(
         deduction_amount=result.deduction,
         net_amount=result.net,
         warnings=result.warnings,
+        items=[],
     )
 
 

--- a/backend/app/schemas/payslip.py
+++ b/backend/app/schemas/payslip.py
@@ -7,6 +7,7 @@ class PayslipPreview(BaseModel):
     deduction_amount: int
     net_amount: int
     warnings: list[str] | None = None
+    items: list[dict] = []
 
 class PayslipCreate(BaseModel):
     filename: str


### PR DESCRIPTION
## Summary
- add `items` field to `PayslipPreview` schema
- always include `items` in upload response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e03a57408329b361440d5b38a932