### PR TITLE
Implement paid leave parsing

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -15,6 +15,8 @@ class Payslip(Base):
     gross_amount = Column(Integer, nullable=True)
     net_amount = Column(Integer, nullable=True)
     deduction_amount = Column(Integer, nullable=True)
+    paid_leave_remaining_days = Column(Float, nullable=True)
+    total_paid_leave_days = Column(Float, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     items = relationship("PayslipItem", back_populates="payslip", cascade="all, delete-orphan")
 

--- a/backend/app/ocr/detailed_parser.py
+++ b/backend/app/ocr/detailed_parser.py
@@ -158,6 +158,8 @@ class DetailedParser(BaseParser):
             deduction=int(parsed["deduction"]),
             net=int(parsed["net"]),
             text="[Gemini parsed]",
+            paid_leave_remaining_days=parsed.get("paid_leave_remaining_days"),
+            total_paid_leave_days=parsed.get("total_paid_leave_days"),
             warnings=None,
             items=[it.model_dump() for it in items] if items else None,
         )

--- a/backend/app/ocr/simple_totals.py
+++ b/backend/app/ocr/simple_totals.py
@@ -125,6 +125,8 @@ class TotalsOnlyParser(BaseParser):
             deduction=deduction,
             net=net,
             text=text,
+            paid_leave_remaining_days=None,
+            total_paid_leave_days=None,
             items=items
         )
 

--- a/backend/app/ocr/strategy.py
+++ b/backend/app/ocr/strategy.py
@@ -10,6 +10,8 @@ class OCRResult:
     net: int
     text: str
     type: Optional[str] = None
+    paid_leave_remaining_days: Optional[float] = None
+    total_paid_leave_days: Optional[float] = None
     warnings: list[str] | None = None
     items: Optional[List[Item]] = None
 

--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -42,6 +42,8 @@ def to_schema(p: models.Payslip) -> PayslipRead:
         gross_amount=p.gross_amount or 0,
         deduction_amount=p.deduction_amount or 0,
         net_amount=p.net_amount or 0,
+        paid_leave_remaining_days=p.paid_leave_remaining_days,
+        total_paid_leave_days=p.total_paid_leave_days,
     )
 
 
@@ -79,6 +81,8 @@ async def upload(
         gross_amount=result.gross,
         deduction_amount=result.deduction,
         net_amount=result.net,
+        paid_leave_remaining_days=result.paid_leave_remaining_days,
+        total_paid_leave_days=result.total_paid_leave_days,
         warnings=warnings_safe,
         items=result.items if result.items else [
             {"name": "支給合計", "amount": result.gross, "category": "支給"},
@@ -98,6 +102,8 @@ def save(payload: PayslipCreate, db: Session = Depends(get_db)):
         gross_amount=payload.gross_amount,
         deduction_amount=payload.deduction_amount,
         net_amount=payload.net_amount,
+        paid_leave_remaining_days=payload.paid_leave_remaining_days,
+        total_paid_leave_days=payload.total_paid_leave_days,
     )
     db.add(p)
     db.flush()

--- a/backend/app/schemas/payslip.py
+++ b/backend/app/schemas/payslip.py
@@ -13,6 +13,8 @@ class PayslipCreate(BaseModel):
     gross_amount: int
     deduction_amount: int
     net_amount: int
+    paid_leave_remaining_days: Optional[float] = None
+    total_paid_leave_days: Optional[float] = None
     items: List[PayslipItemSchema] = []
 
 class PayslipPreview(BaseModel):

--- a/backend/tests/test_parser.py
+++ b/backend/tests/test_parser.py
@@ -8,6 +8,8 @@ def test_parse_totals():
     assert result.gross == 200
     assert result.deduction == 50
     assert result.net == 150
+    assert result.paid_leave_remaining_days is None
+    assert result.total_paid_leave_days is None
 
 
 def test_parse_without_gross():

--- a/frontend/pages/payslip/[id].tsx
+++ b/frontend/pages/payslip/[id].tsx
@@ -115,6 +115,12 @@ export default function PayslipDetail() {
       ) : (
         <Stack spacing={4}>
           <Heading as="h1" size="lg">{data.filename}</Heading>
+          {data.paid_leave_remaining_days !== undefined && (
+            <Text>
+              残有給: {data.paid_leave_remaining_days ?? '-'}日 / 年休付与:
+              {data.total_paid_leave_days ?? '-'}日
+            </Text>
+          )}
           {data.warnings && data.warnings.length > 0 && (
             <Stack>
               {data.warnings.map((w: string, i: number) => (

--- a/frontend/pages/upload.tsx
+++ b/frontend/pages/upload.tsx
@@ -83,6 +83,8 @@ export default function Upload() {
         gross_amount: preview.gross_amount,
         net_amount: preview.net_amount,
         deduction_amount: preview.deduction_amount,
+        paid_leave_remaining_days: preview.paid_leave_remaining_days,
+        total_paid_leave_days: preview.total_paid_leave_days,
         items: preview.items ? preview.items.map((it: any) => ({
           name: it.name,
           amount: it.amount,
@@ -114,6 +116,12 @@ export default function Upload() {
         {preview && (
           <Box>
             {file && <Image src={URL.createObjectURL(file)} alt="preview" maxW="200px" />}
+            {preview.paid_leave_remaining_days !== undefined && (
+              <Text mt={2}>
+                残有給: {preview.paid_leave_remaining_days ?? '-'}日 / 年休付与:
+                {preview.total_paid_leave_days ?? '-'}日
+              </Text>
+            )}
             <SimpleGrid columns={2} spacing={2} mt={2}>
               {preview.items?.map((it: any, i: number) => (
                 <Box key={i} p={2} borderWidth="1px" borderRadius="md">


### PR DESCRIPTION
## Summary
- capture paid leave data in OCR result dataclass
- store paid leave info on payslip model and schema
- expose new values through payslip API
- display paid leave amounts on upload preview and payslip detail pages
- cover new fields with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684996bcbaac832982e71f05986ba5c1