### PR TITLE
Fix missing Float import

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Date, DateTime, ForeignKey, Float
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from datetime import datetime


### PR DESCRIPTION
## Summary
- add `Float` type to SQLAlchemy imports for payslip models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d432f1f388329aa365917967dd4a5