### PR TITLE
Fix type annotation in settings router

### DIFF
--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
+from typing import Any
 
 router = APIRouter()
 
 # simple in-memory store
-SETTINGS: dict[str, any] = {
+SETTINGS: dict[str, Any] = {
     "theme_color": "#319795",
     "dark_mode": False,
     "items": []


### PR DESCRIPTION
## Summary
- update settings router annotation to `dict[str, Any]`
- import `Any` from typing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d438cdf1883299a4a7838b677e8fb