### PR TITLE
Add year filter to payslip_stats

### DIFF
--- a/backend/app/routers/payslip.py
+++ b/backend/app/routers/payslip.py
@@ -174,11 +174,19 @@ def payslip_stats(
     period: str = "monthly",
     target: str = "net",
     kind: str | None = None,
+    year: int | None = None,
     db: Session = Depends(get_db),
 ):
     query = db.query(models.Payslip)
     if kind:
         query = query.filter(models.Payslip.type == kind)
+    if year is not None:
+        start_date = date(year, 1, 1)
+        end_date = date(year, 12, 31)
+        query = query.filter(
+            models.Payslip.date >= start_date,
+            models.Payslip.date <= end_date,
+        )
     records = query.all()
 
     grouped: dict[str, int] = {}


### PR DESCRIPTION
## Summary
- add an optional year parameter to `payslip_stats`
- filter payslip records by year when provided

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d4473e2dc832994082344802fc898